### PR TITLE
[bug] Amazon の複数ページの領収書に対応できていない

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Commands:
 python cli.py add-text-to-pdf \
   --input-filename ./sample/dummy.pdf \
   --text-position-preset top-right \
-  --text "Hello World Co., Ltd." \
-  --font-size 13
+  --text "Hello World Co., Ltd."
 ```
 
 ### 複数の PDF ファイルにテキストを挿入する
@@ -49,10 +48,8 @@ python cli.py add-text-to-pdf \
 ```sh
 python cli.py add-text-to-pdf-files \
   --input-dir ./sample \
-  --output-dir ./sample/output \
   --text-position-preset top-left \
-  --text "株式会社ハローワールド" \
-  --font-size 13
+  --text "株式会社ハローワールド"
 ```
 
 - テキスト挿入位置を座標で指定する
@@ -60,22 +57,18 @@ python cli.py add-text-to-pdf-files \
 ```sh
 python cli.py add-text-to-pdf-files \
   --input-dir ./sample \
-  --output-dir ./sample/output \
   --text-position-x 100 \
   --text-position-y 100 \
   --text "Hello World Co., Ltd." \
-  --font-size 13
 ```
 
-- 複数の Amazon の領収書 PDF の右上の宛名欄に会社名を挿入する
+- 複数の Amazon の領収書 PDF の右上の宛名欄に宛名を挿入する
 
 そもそもこれやるために作った。
 
 ```sh
 python cli.py add-text-to-pdf-files \
   --input-dir path/to/receipts \
-  --output-dir path/to/receipts/output \
   --text-position-preset amazon-receipt \
-  --text "株式会社ハローワールド" \
-  --font-size 13
+  --text "株式会社ハローワールド 三愛太郎" \
 ```

--- a/commands.py
+++ b/commands.py
@@ -78,7 +78,7 @@ def add_text_to_pdf(
 @click.option(
     "--output-dir",
     default="",
-    help="PDF files directory for output. If not specified, the directory will be {input dir}.",
+    help="PDF files directory for output. If not specified, the directory will be \"{input dir}/output\".",
 )
 @click.option(
     "--text",
@@ -125,8 +125,16 @@ def add_text_to_pdf_files(
 
     # add text to pdf files
     for input_fname in pdf_filenames:
-        output_fname = ""
-        if output_dir != "":
+        if output_dir == "":
+            # デフォルト
+            output_path = Path(input_dir, "output")
+            output_path.mkdir(parents=True, exist_ok=True)
+
+            output_fname = os.path.join(
+                output_path,
+                os.path.basename(input_fname),
+            )
+        else:
             # create output_dir if not exists
             output_path = Path(output_dir)
             output_path.mkdir(parents=True, exist_ok=True)

--- a/pdf.py
+++ b/pdf.py
@@ -94,13 +94,19 @@ def add_text_to_pdf(
     pdf_for_addition_text = PdfFileReader(buffer)
 
     # 編集対象の PDF の 1 ページ目を読み取り、テキスト挿入用の PDF の 1 ページ目をマージ
-    page_input = existing_pdf.getPage(0)
+    page_input = existing_pdf.getPage(0)  # PdfFileReader のページは 0-origin
     page_text = pdf_for_addition_text.getPage(0)
     page_input.mergePage(page_text)
 
     # 出力
     output = PdfFileWriter()
     output.addPage(page_input)
+
+    # 2 ページ目以降ページの追加
+    for i in range(1, existing_pdf.getNumPages()):
+        page = existing_pdf.getPage(i)
+        output.addPage(page)
+
     if output_filename == "":
         # input ファイルと同じディレクトリに出力
         output_dir = os.path.dirname(input_filename)

--- a/pdf.py
+++ b/pdf.py
@@ -10,15 +10,16 @@ from reportlab.pdfgen import canvas
 
 
 # constants
-FONT_SIZE = 13
+FONT_SIZE = 9
 
 # A4 = (210*mm, 297*mm)
+# page 左下が基準座標 (0, 0)
 TOP = 280  # y
 BOTTOM = 10  # y
 LEFT = 10  # x
 RIGHT = 150  # x
-AMAZON_X = 150
-AMAZON_Y = 243
+AMAZON_X = 145
+AMAZON_Y = 261
 
 TEXT_POSITION_PRESETS = [
     "top-left",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [tool.poetry]
-name = "pdf-amazon-receipt"
+name = "pdf-text-adder-py"
 version = "0.1.0"
 description = ""
 authors = ["nukopy <nukopy@gmail.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "pdf_amazon_receipt"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pdf-text-adder-py"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["nukopy <nukopy@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Fix #1

## What

- bugfix
  - [x] マルチページの PDF ファイルへの対応ができていない
  - [x] プリセット "amazon-receipt" のテキスト挿入位置がおかしい
- その他
  - [x] 証憑として使用する宛名に "会社名 名字名前" が必要になるので、その分プリセット "amazon-receipt" のテキスト挿入位置を調整する